### PR TITLE
Add AllowOnlineAffirmPayment property to IPPInvoice

### DIFF
--- a/src/Data/IPPInvoice.php
+++ b/src/Data/IPPInvoice.php
@@ -158,6 +158,20 @@ class IPPInvoice
 	/**
 	 * @Definition
 								Product: QBO
+								Description: Specifies whether
+								customer is allowed to use eInvoicing(online payment -
+								affirm) to pay the Invoice
+
+	 * @xmlType element
+	 * @xmlNamespace http://schema.intuit.com/finance/v3
+	 * @xmlMinOccurs 0
+	 * @xmlName AllowOnlineAffirmPayment
+	 * @var boolean
+	 */
+	public $AllowOnlineAffirmPayment;
+	/**
+	 * @Definition
+								Product: QBO
 								Description: Specifies the eInvoice
 								Status(SENT, VIEWED, PAID) for the invoice
 


### PR DESCRIPTION
Intuit added Affirm as an online payment option and QBO now returns an AllowOnlineAffirmPayment field on the Invoice entity. Without this property declared, Bind::bindXml() throws a ReflectionException when parsing invoices that include the field.

Cherry-picked from upstream intuit/QuickBooks-V3-PHP-SDK#577, which fixes intuit/QuickBooks-V3-PHP-SDK#575 and is included in upstream v6.2.5/v6.3.1.